### PR TITLE
feat: プロフィールにstreak・activity graph・トロフィー・パックマンを追加

### DIFF
--- a/.github/workflows/pacman.yml
+++ b/.github/workflows/pacman.yml
@@ -1,0 +1,30 @@
+name: generate pacman contribution graph
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  generate:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: generate pacman-contribution-graph.svg
+        uses: abozanona/pacman-contribution-graph@main
+        with:
+          github_user_name: ${{ github.repository_owner }}
+
+      - name: push pacman-contribution-graph.svg to the output branch
+        uses: crazy-max/ghaction-github-pages@v3.1.0
+        with:
+          target_branch: output
+          build_dir: dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@
 ](http://qiita.com/miwashutaro0611)
 [![](https://qiita-badge.apiapi.app/s/miwashutaro0611/contributions.svg)
 ](http://qiita.com/miwashutaro0611)
-[![]()]()
 [![](https://zenn.badge.nikaera.com/s/jackmiwamiwa/articles?style=plastic)](https://zenn.dev/jackmiwamiwa/articles)
 [![](https://zenn.badge.nikaera.com/s/jackmiwamiwa/likes?style=plastic)](https://zenn.dev/jackmiwamiwa)
 
 [このプロフィールページで対応したことについて](https://jackswim3411.hatenablog.com/entry/2021/09/18/205206)
+
+## 📊 Stats
 
 ![](https://github-profile-summary-cards.vercel.app/api/cards/profile-details?username=miwashutaro0611&theme=dracula)
 
@@ -26,3 +27,28 @@
 </a>
 </p>
 
+<br clear="left" />
+
+## 🔥 Contributions
+
+<a href="https://github.com/miwashutaro0611">
+  <img src="https://streak-stats.demolab.com?user=miwashutaro0611&theme=dracula&date_format=Y%2Fn%2Fj" alt="GitHub Streak" />
+</a>
+
+<a href="https://github.com/miwashutaro0611">
+  <img src="https://github-readme-activity-graph.vercel.app/graph?username=miwashutaro0611&theme=dracula&hide_border=false" alt="Activity Graph" />
+</a>
+
+## 🏆 Trophies
+
+<a href="https://github.com/miwashutaro0611">
+  <img src="https://trophy.benkou.dev/?username=miwashutaro0611&theme=dracula&column=7&margin-w=8&margin-h=8" alt="GitHub Trophies" />
+</a>
+
+## 👾 Pac-Man
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/miwashutaro0611/miwashutaro0611/output/pacman-contribution-graph-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/miwashutaro0611/miwashutaro0611/output/pacman-contribution-graph.svg">
+  <img alt="pacman contribution graph" src="https://raw.githubusercontent.com/miwashutaro0611/miwashutaro0611/output/pacman-contribution-graph.svg">
+</picture>


### PR DESCRIPTION
## 概要

[beautify-github-profile](https://github.com/rzashakeri/beautify-github-profile) を参考に、GitHubプロフィールをリッチにするための要素を追加しました。
直近のコミット状況が一目で分かるカードと、トロフィー・パックマンアニメーションを導入し、READMEをセクション構成に整理しています。

## 変更内容

- **🔥 Contributions セクションを追加**: Streak Stats（総コントリビューション数・連続コミット日数）と Activity Graph（直近31日間のアクティビティ）を表示
- **🏆 Trophies セクションを追加**: github-profile-trophy によるトロフィー表示（公式インスタンスが停止中のため、公式README掲載のミラー trophy.benkou.dev を使用）
- **👾 Pac-Man セクションを追加**: コントリビューショングラフをパックマンが食べるアニメーション（ダーク/ライトテーマ自動切替対応）
- **GitHub Actions ワークフローを追加** (`.github/workflows/pacman.yml`): 毎日0時（UTC）にパックマンSVGを生成して output ブランチへ push
- 既存カードを「📊 Stats」セクションとして整理し、空バッジ `[![]()]()` を削除。テーマは dracula で統一

## 動作確認

- [x] Streak Stats・Activity Graph・Trophies の各URLが HTTP 200 でSVGを返すことを確認済み
- [ ] マージ後、Actions の `generate pacman contribution graph` が成功し、README にパックマンが表示されること

## 補足

- パックマンのSVGは output ブランチに生成されるため、**マージしてワークフローが初回実行されるまでは README 上で404** になります（Actionsタブから手動実行も可能です）。
- 既存の github-readme-stats.vercel.app のカードは現在公式インスタンスが一時停止中（DEPLOYMENT_PAUSED）ですが、従来からの利用のためURLは維持しています。通常は自然復旧します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)